### PR TITLE
[codex] Add typed LMDB indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,23 @@ cd /srv/opendr-consumer && opendr
 
 For LMDB-backed instances, generate the `{SSHA512}` root password with `opendr-setup` or reuse the generated hash from an existing server config, then mount it through `root_password_file` or export it via `root_password_env`.
 
+LMDB index configuration supports the legacy shortcut and typed indexes. `indexed_attributes = ["cn", "uid"]` maintains equality and presence keys. Use typed entries when a custom attribute needs substring or ordering candidates:
+
+```toml
+[backend]
+indexed_attributes = ["cn", "uid", "mail", "objectClass", "ou"]
+
+[[backend.indexes]]
+attribute = "cn"
+types = ["substring"]
+
+[[backend.indexes]]
+attribute = "entryCSN"
+types = ["ordering"]
+```
+
+When a new index is configured after data already exists, the LMDB backend rebuilds the configured attribute index keys during startup without modifying LDAP entries, operational attributes, or CSNs. Approximate-match filters currently use the equality index path because OpenDR's approximate-match semantics are case-insensitive equality.
+
 ### 5. Verify Listener-Based Replication
 
 Add data to the provider:

--- a/config/server.toml
+++ b/config/server.toml
@@ -14,6 +14,17 @@ backend_type = "lmdb"
 data_directory = "./data"
 lmdb_max_size = 10737418240  # 10GB
 lmdb_max_readers = 256
+# Legacy indexed_attributes entries get equality and presence indexes.
+# indexed_attributes = ["cn", "uid", "mail", "objectClass", "ou"]
+#
+# Typed indexes can add OpenDJ-style index categories for custom attributes.
+# [[backend.indexes]]
+# attribute = "cn"
+# types = ["substring"]
+#
+# [[backend.indexes]]
+# attribute = "entryCSN"
+# types = ["ordering"]
 
 [resources]
 # Support at least 128 concurrent clients from the same Docker bridge / proxy IP

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -364,8 +364,32 @@ pub enum ModifyOperation {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SearchCandidateHint {
-    Equality { attribute: String, value: String },
-    Present { attribute: String },
+    Equality {
+        attribute: String,
+        value: String,
+    },
+    Present {
+        attribute: String,
+    },
+    Substring {
+        attribute: String,
+        parts: Vec<SearchSubstringPart>,
+    },
+    GreaterOrEqual {
+        attribute: String,
+        value: String,
+    },
+    LessOrEqual {
+        attribute: String,
+        value: String,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SearchSubstringPart {
+    Initial(String),
+    Any(String),
+    Final(String),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/backend_lmdb.rs
+++ b/src/backend_lmdb.rs
@@ -23,7 +23,7 @@
 //! - Indexed attribute lookups
 //! - DN normalization for fast case-insensitive searches
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
@@ -38,7 +38,7 @@ use tokio::sync::RwLock;
 
 use crate::backend::{
     BackendError, DirectoryBackend, DirectoryEntry, Modification, ModifyOperation,
-    SearchCandidateHint,
+    SearchCandidateHint, SearchSubstringPart,
 };
 use crate::csn::CsnGenerator;
 use crate::metrics::MetricsCollector;
@@ -46,8 +46,11 @@ use crate::metrics::MetricsCollector;
 const LMDB_SET_RANGE_OP: u32 = 17;
 const DEFAULT_ENTRY_CACHE_CAPACITY: usize = 1000;
 const PRESENCE_INDEX_VALUE_SENTINEL: &str = "\0present";
-const PRESENCE_INDEX_VERSION: &[u8] = b"1";
-const PRESENCE_INDEX_MIGRATION_BATCH_SIZE: usize = 4096;
+const SUBSTRING_INDEX_KEY_PREFIX: &str = "\0sub\0";
+const ORDERING_INDEX_KEY_PREFIX: &str = "\0ord\0";
+const SUBSTRING_INDEX_TOKEN_LEN: usize = 3;
+const ATTRIBUTE_INDEX_VERSION: &[u8] = b"1";
+const ATTRIBUTE_INDEX_CONFIG_METADATA_KEY: &str = "attribute_indexes_v1:configured";
 
 /// Serialized entry structure for LMDB storage
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -367,8 +370,45 @@ impl StoredEntry {
 /// Configuration for indexed attributes
 #[derive(Debug, Clone)]
 pub struct IndexConfig {
-    /// Attributes that should be indexed
+    /// Legacy attributes that should get equality and presence indexes.
     pub indexed_attributes: Vec<String>,
+    /// Typed attribute indexes. These are merged with `indexed_attributes`.
+    pub attribute_indexes: Vec<AttributeIndexConfig>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AttributeIndexConfig {
+    pub attribute: String,
+    pub index_types: Vec<IndexType>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum IndexType {
+    Equality,
+    Presence,
+    Substring,
+    Ordering,
+}
+
+impl IndexType {
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name.to_ascii_lowercase().as_str() {
+            "equality" | "eq" => Some(Self::Equality),
+            "presence" | "pres" => Some(Self::Presence),
+            "substring" | "sub" => Some(Self::Substring),
+            "ordering" | "ord" => Some(Self::Ordering),
+            _ => None,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Equality => "equality",
+            Self::Presence => "presence",
+            Self::Substring => "substring",
+            Self::Ordering => "ordering",
+        }
+    }
 }
 
 impl Default for IndexConfig {
@@ -382,7 +422,57 @@ impl Default for IndexConfig {
                 "objectclass".to_string(),
                 "ou".to_string(),
             ],
+            attribute_indexes: Vec::new(),
         }
+    }
+}
+
+impl IndexConfig {
+    pub fn disabled() -> Self {
+        Self {
+            indexed_attributes: Vec::new(),
+            attribute_indexes: Vec::new(),
+        }
+    }
+
+    fn effective_index_types(&self) -> BTreeMap<String, BTreeSet<IndexType>> {
+        let mut indexes = BTreeMap::new();
+
+        for attribute in &self.indexed_attributes {
+            let attribute = attribute.to_lowercase();
+            if attribute.is_empty() {
+                continue;
+            }
+            let index_types = indexes.entry(attribute).or_insert_with(BTreeSet::new);
+            index_types.insert(IndexType::Equality);
+            index_types.insert(IndexType::Presence);
+        }
+
+        for configured in &self.attribute_indexes {
+            let attribute = configured.attribute.to_lowercase();
+            if attribute.is_empty() {
+                continue;
+            }
+            let index_types = indexes.entry(attribute).or_insert_with(BTreeSet::new);
+            for index_type in &configured.index_types {
+                index_types.insert(*index_type);
+            }
+        }
+
+        indexes.retain(|_, index_types| !index_types.is_empty());
+        indexes
+    }
+
+    fn index_types_for(&self, attribute: &str) -> Option<BTreeSet<IndexType>> {
+        self.effective_index_types()
+            .get(&attribute.to_lowercase())
+            .cloned()
+    }
+
+    fn has_index_type(&self, attribute: &str, index_type: IndexType) -> bool {
+        self.effective_index_types()
+            .get(&attribute.to_lowercase())
+            .is_some_and(|index_types| index_types.contains(&index_type))
     }
 }
 
@@ -514,19 +604,27 @@ impl LmdbBackend {
             .create_db(Some("metadata"), lmdb::DatabaseFlags::empty())
             .map_err(|e| BackendError::Storage(format!("Failed to create metadata db: {}", e)))?;
 
+        let effective_index_types = index_config.effective_index_types();
+
         // Create attribute index databases.
         let mut attr_indexes = HashMap::new();
-        for attr in &index_config.indexed_attributes {
-            let db_name = format!("idx_{}", attr.to_lowercase());
+        for attr in effective_index_types.keys() {
+            let db_name = format!("idx_{}", attr);
             let db = env
                 .create_db(Some(&db_name), lmdb::DatabaseFlags::empty())
                 .map_err(|e| {
                     BackendError::Storage(format!("Failed to create index for {}: {}", attr, e))
                 })?;
-            attr_indexes.insert(attr.to_lowercase(), db);
+            attr_indexes.insert(attr.clone(), db);
         }
 
-        Self::ensure_presence_index_markers(&env, entries_db, metadata_db, &attr_indexes)?;
+        Self::ensure_attribute_indexes_backfilled(
+            &env,
+            entries_db,
+            metadata_db,
+            &attr_indexes,
+            &effective_index_types,
+        )?;
 
         // Initialize CSN generator with replica ID
         let csn_generator = Arc::new(CsnGenerator::new(replica_id));
@@ -1254,163 +1352,299 @@ impl LmdbBackend {
         Self::equality_index_prefix(PRESENCE_INDEX_VALUE_SENTINEL)
     }
 
-    fn presence_index_metadata_key(attribute: &str) -> String {
-        format!("presence_index_v1:{}", attribute)
+    fn substring_index_key(token: &str, dn: &str) -> String {
+        format!("{SUBSTRING_INDEX_KEY_PREFIX}{token}\0{dn}")
     }
 
-    fn ensure_presence_index_markers(
+    fn substring_index_prefix(token: &str) -> String {
+        format!("{SUBSTRING_INDEX_KEY_PREFIX}{token}\0")
+    }
+
+    fn ordering_index_key(value: &str, dn: &str) -> String {
+        format!("{ORDERING_INDEX_KEY_PREFIX}{value}\0{dn}")
+    }
+
+    fn ordering_index_prefix() -> &'static str {
+        ORDERING_INDEX_KEY_PREFIX
+    }
+
+    fn ordering_index_key_parts(key: &[u8]) -> Result<Option<(&str, &str)>, BackendError> {
+        let key = std::str::from_utf8(key)
+            .map_err(|e| BackendError::Storage(format!("Invalid UTF-8 in index key: {}", e)))?;
+        Ok(key
+            .strip_prefix(ORDERING_INDEX_KEY_PREFIX)
+            .and_then(|suffix| suffix.split_once('\0')))
+    }
+
+    fn attribute_index_keys(
+        index_db: Database,
+        dn: &str,
+        values: &[String],
+        index_types: &BTreeSet<IndexType>,
+    ) -> Vec<(Database, String)> {
+        let mut index_keys = Vec::new();
+
+        if index_types.contains(&IndexType::Presence) && !values.is_empty() {
+            index_keys.push((index_db, Self::presence_index_key(dn)));
+        }
+
+        for value in values {
+            let value_lower = value.to_lowercase();
+
+            if index_types.contains(&IndexType::Equality) {
+                index_keys.push((index_db, Self::equality_index_key(&value_lower, dn)));
+            }
+
+            if index_types.contains(&IndexType::Substring) {
+                for token in Self::substring_index_tokens(&value_lower) {
+                    index_keys.push((index_db, Self::substring_index_key(&token, dn)));
+                }
+            }
+
+            if index_types.contains(&IndexType::Ordering) {
+                index_keys.push((index_db, Self::ordering_index_key(&value_lower, dn)));
+            }
+        }
+
+        index_keys
+    }
+
+    fn substring_index_tokens(value: &str) -> BTreeSet<String> {
+        let chars = value.chars().collect::<Vec<_>>();
+        if chars.len() < SUBSTRING_INDEX_TOKEN_LEN {
+            return BTreeSet::new();
+        }
+
+        chars
+            .windows(SUBSTRING_INDEX_TOKEN_LEN)
+            .map(|window| window.iter().collect::<String>())
+            .collect()
+    }
+
+    fn substring_query_token(parts: &[SearchSubstringPart]) -> Option<String> {
+        let best_segment = parts
+            .iter()
+            .map(|part| match part {
+                SearchSubstringPart::Initial(value)
+                | SearchSubstringPart::Any(value)
+                | SearchSubstringPart::Final(value) => value,
+            })
+            .filter(|value| value.chars().count() >= SUBSTRING_INDEX_TOKEN_LEN)
+            .max_by_key(|value| value.chars().count())?;
+
+        Some(
+            best_segment
+                .to_lowercase()
+                .chars()
+                .take(SUBSTRING_INDEX_TOKEN_LEN)
+                .collect(),
+        )
+    }
+
+    fn attribute_index_metadata_key(attribute: &str) -> String {
+        format!("attribute_index_v1:{}", attribute)
+    }
+
+    fn attribute_index_config_value(index_types: &BTreeMap<String, BTreeSet<IndexType>>) -> String {
+        index_types
+            .iter()
+            .map(|(attribute, types)| {
+                let labels = types
+                    .iter()
+                    .map(|index_type| index_type.label())
+                    .collect::<Vec<_>>()
+                    .join(",");
+                format!("{attribute}:{labels}")
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    fn ensure_attribute_indexes_backfilled(
         env: &Arc<Environment>,
         entries_db: Database,
         metadata_db: Database,
         attr_indexes: &HashMap<String, Database>,
+        index_types: &BTreeMap<String, BTreeSet<IndexType>>,
     ) -> Result<(), BackendError> {
+        let configured_attributes = Self::attribute_index_config_value(index_types);
         let pending_indexes = {
             let txn = env.begin_ro_txn().map_err(|e| {
                 BackendError::Storage(format!(
-                    "Failed to begin presence index version read txn: {}",
+                    "Failed to begin attribute index metadata read txn: {}",
                     e
                 ))
             })?;
-            let mut pending = Vec::new();
-            for (attr, index_db) in attr_indexes {
-                let metadata_key = Self::presence_index_metadata_key(attr);
-                match txn.get(metadata_db, &metadata_key.as_bytes()) {
-                    Ok(value) if value == PRESENCE_INDEX_VERSION => {}
-                    Ok(_) | Err(lmdb::Error::NotFound) => {
-                        pending.push((attr.clone(), *index_db));
-                    }
+            let config_changed =
+                match txn.get(metadata_db, &ATTRIBUTE_INDEX_CONFIG_METADATA_KEY.as_bytes()) {
+                    Ok(value) => value != configured_attributes.as_bytes(),
+                    Err(lmdb::Error::NotFound) => true,
                     Err(e) => {
                         return Err(BackendError::Storage(format!(
-                            "Failed to read presence index metadata for {}: {}",
-                            attr, e
+                            "Failed to read attribute index config metadata: {}",
+                            e
                         )))
                     }
-                }
-            }
-            pending
-        };
+                };
 
-        if pending_indexes.is_empty() {
-            return Ok(());
-        }
-
-        let pending_by_attr = pending_indexes.iter().cloned().collect::<HashMap<_, _>>();
-        let mut last_key = None;
-
-        loop {
-            let mut markers = Vec::with_capacity(PRESENCE_INDEX_MIGRATION_BATCH_SIZE);
-            let mut batch_full = false;
-
-            {
-                let txn = env.begin_ro_txn().map_err(|e| {
-                    BackendError::Storage(format!(
-                        "Failed to begin presence index migration read txn: {}",
-                        e
-                    ))
-                })?;
-                let mut cursor = txn.open_ro_cursor(entries_db).map_err(|e| {
-                    BackendError::Storage(format!(
-                        "Failed to open entries cursor for presence index migration: {}",
-                        e
-                    ))
-                })?;
-
-                if let Some(last_key) = last_key.as_deref() {
-                    match cursor.get(Some(last_key), None, LMDB_SET_RANGE_OP) {
-                        Ok(_) => {}
-                        Err(lmdb::Error::NotFound) => break,
+            if config_changed {
+                attr_indexes
+                    .iter()
+                    .filter_map(|(attr, index_db)| {
+                        index_types
+                            .get(attr)
+                            .map(|types| (attr.clone(), *index_db, types.clone()))
+                    })
+                    .collect::<Vec<_>>()
+            } else {
+                let mut pending = Vec::new();
+                for (attr, index_db) in attr_indexes {
+                    let metadata_key = Self::attribute_index_metadata_key(attr);
+                    match txn.get(metadata_db, &metadata_key.as_bytes()) {
+                        Ok(value) if value == ATTRIBUTE_INDEX_VERSION => {}
+                        Ok(_) | Err(lmdb::Error::NotFound) => {
+                            if let Some(types) = index_types.get(attr) {
+                                pending.push((attr.clone(), *index_db, types.clone()));
+                            }
+                        }
                         Err(e) => {
                             return Err(BackendError::Storage(format!(
-                                "Failed to seek entries cursor for presence index migration: {}",
-                                e
+                                "Failed to read attribute index metadata for {}: {}",
+                                attr, e
                             )))
                         }
                     }
                 }
-
-                for (entry_key, entry_bytes) in cursor.iter() {
-                    last_key = Some(entry_key.to_vec());
-                    let entry: StoredEntry = bincode::deserialize(entry_bytes).map_err(|e| {
-                        BackendError::Storage(format!(
-                            "Failed to deserialize entry during presence index migration: {}",
-                            e
-                        ))
-                    })?;
-
-                    for (attr_name, values) in &entry.attributes {
-                        if values.is_empty() {
-                            continue;
-                        }
-                        let attr_lower = attr_name.to_lowercase();
-                        if let Some(index_db) = pending_by_attr.get(&attr_lower) {
-                            markers.push((*index_db, Self::presence_index_key(&entry.dn)));
-                        }
-                    }
-
-                    if markers.len() >= PRESENCE_INDEX_MIGRATION_BATCH_SIZE {
-                        batch_full = true;
-                        break;
-                    }
-                }
+                pending
             }
+        };
 
-            if markers.is_empty() {
-                break;
-            }
-
+        if pending_indexes.is_empty() {
             let mut txn = env.begin_rw_txn().map_err(|e| {
                 BackendError::Storage(format!(
-                    "Failed to begin presence index migration write txn: {}",
+                    "Failed to begin attribute index config metadata write txn: {}",
                     e
                 ))
             })?;
-            for (index_db, marker_key) in markers {
-                txn.put(index_db, &marker_key.as_bytes(), &[], WriteFlags::empty())
-                    .map_err(|e| {
-                        BackendError::Storage(format!(
-                            "Failed to write migrated presence index marker: {}",
-                            e
-                        ))
-                    })?;
-            }
-            txn.commit().map_err(|e| {
-                BackendError::Storage(format!(
-                    "Failed to commit presence index migration batch: {}",
-                    e
-                ))
-            })?;
-
-            if !batch_full {
-                break;
-            }
-        }
-
-        let mut txn = env.begin_rw_txn().map_err(|e| {
-            BackendError::Storage(format!(
-                "Failed to begin presence index metadata write txn: {}",
-                e
-            ))
-        })?;
-        for (attr, _) in pending_indexes {
-            let metadata_key = Self::presence_index_metadata_key(&attr);
             txn.put(
                 metadata_db,
-                &metadata_key.as_bytes(),
-                &PRESENCE_INDEX_VERSION,
+                &ATTRIBUTE_INDEX_CONFIG_METADATA_KEY.as_bytes(),
+                &configured_attributes.as_bytes(),
                 WriteFlags::empty(),
             )
             .map_err(|e| {
                 BackendError::Storage(format!(
-                    "Failed to mark presence index migration complete for {}: {}",
+                    "Failed to mark attribute index config metadata: {}",
+                    e
+                ))
+            })?;
+            txn.commit().map_err(|e| {
+                BackendError::Storage(format!(
+                    "Failed to commit attribute index config metadata: {}",
+                    e
+                ))
+            })?;
+            return Ok(());
+        }
+
+        let pending_by_attr = pending_indexes
+            .iter()
+            .map(|(attr, index_db, types)| (attr.clone(), (*index_db, types.clone())))
+            .collect::<HashMap<_, _>>();
+        let index_entries = {
+            let txn = env.begin_ro_txn().map_err(|e| {
+                BackendError::Storage(format!(
+                    "Failed to begin attribute index backfill read txn: {}",
+                    e
+                ))
+            })?;
+            let mut cursor = txn.open_ro_cursor(entries_db).map_err(|e| {
+                BackendError::Storage(format!(
+                    "Failed to open entries cursor for attribute index backfill: {}",
+                    e
+                ))
+            })?;
+
+            let mut index_entries = Vec::new();
+            for (_, entry_bytes) in cursor.iter() {
+                let entry: StoredEntry = bincode::deserialize(entry_bytes).map_err(|e| {
+                    BackendError::Storage(format!(
+                        "Failed to deserialize entry during attribute index backfill: {}",
+                        e
+                    ))
+                })?;
+
+                for (attr_name, values) in &entry.attributes {
+                    if values.is_empty() {
+                        continue;
+                    }
+
+                    let attr_lower = attr_name.to_lowercase();
+                    if let Some((index_db, types)) = pending_by_attr.get(&attr_lower) {
+                        index_entries.extend(Self::attribute_index_keys(
+                            *index_db, &entry.dn, values, types,
+                        ));
+                    }
+                }
+            }
+
+            index_entries
+        };
+
+        let mut txn = env.begin_rw_txn().map_err(|e| {
+            BackendError::Storage(format!(
+                "Failed to begin attribute index backfill write txn: {}",
+                e
+            ))
+        })?;
+
+        for (_, index_db, _) in &pending_indexes {
+            txn.clear_db(*index_db).map_err(|e| {
+                BackendError::Storage(format!("Failed to clear attribute index: {}", e))
+            })?;
+        }
+
+        for (index_db, index_key) in index_entries {
+            txn.put(index_db, &index_key.as_bytes(), &[], WriteFlags::empty())
+                .map_err(|e| {
+                    BackendError::Storage(format!(
+                        "Failed to write backfilled attribute index key: {}",
+                        e
+                    ))
+                })?;
+        }
+
+        for (attr, _, _) in pending_indexes {
+            let metadata_key = Self::attribute_index_metadata_key(&attr);
+            txn.put(
+                metadata_db,
+                &metadata_key.as_bytes(),
+                &ATTRIBUTE_INDEX_VERSION,
+                WriteFlags::empty(),
+            )
+            .map_err(|e| {
+                BackendError::Storage(format!(
+                    "Failed to mark attribute index backfill complete for {}: {}",
                     attr, e
                 ))
             })?;
         }
-        txn.commit().map_err(|e| {
+
+        txn.put(
+            metadata_db,
+            &ATTRIBUTE_INDEX_CONFIG_METADATA_KEY.as_bytes(),
+            &configured_attributes.as_bytes(),
+            WriteFlags::empty(),
+        )
+        .map_err(|e| {
             BackendError::Storage(format!(
-                "Failed to commit presence index metadata update: {}",
+                "Failed to mark attribute index config metadata: {}",
                 e
             ))
+        })?;
+
+        txn.commit().map_err(|e| {
+            BackendError::Storage(format!("Failed to commit attribute index backfill: {}", e))
         })?;
 
         Ok(())
@@ -1463,7 +1697,8 @@ impl LmdbBackend {
     /// Update attribute indexes for an entry
     ///
     /// This method updates the attribute indexes when an entry is added or modified.
-    /// For each indexed attribute, it creates an index entry mapping `value:dn` -> ``.
+    /// For each indexed attribute, it creates the configured equality, presence,
+    /// substring, and ordering keys.
     fn update_attribute_indexes(
         &self,
         txn: &mut lmdb::RwTransaction,
@@ -1480,32 +1715,18 @@ impl LmdbBackend {
 
             // Check if this attribute is indexed
             if let Some(index_db) = indexes.get(&attr_lower) {
-                if !values.is_empty() {
-                    let presence_key = Self::presence_index_key(dn);
-                    txn.put(
-                        *index_db,
-                        &presence_key.as_bytes(),
-                        &[],
-                        WriteFlags::empty(),
-                    )
-                    .map_err(|e| {
-                        BackendError::Storage(format!(
-                            "Failed to update presence index for {}: {}",
-                            attr_name, e
-                        ))
-                    })?;
-                }
-
-                for value in values {
-                    let value_lower = value.to_lowercase();
-                    let index_key = Self::equality_index_key(&value_lower, dn);
-                    txn.put(*index_db, &index_key.as_bytes(), &[], WriteFlags::empty())
-                        .map_err(|e| {
-                            BackendError::Storage(format!(
-                                "Failed to update index for {}:{}: {}",
-                                attr_name, value, e
-                            ))
-                        })?;
+                if let Some(index_types) = self.index_config.index_types_for(&attr_lower) {
+                    for (_, index_key) in
+                        Self::attribute_index_keys(*index_db, dn, values, &index_types)
+                    {
+                        txn.put(*index_db, &index_key.as_bytes(), &[], WriteFlags::empty())
+                            .map_err(|e| {
+                                BackendError::Storage(format!(
+                                    "Failed to update index for {}: {}",
+                                    attr_name, e
+                                ))
+                            })?;
+                    }
                 }
             }
         }
@@ -1532,29 +1753,19 @@ impl LmdbBackend {
 
             // Check if this attribute is indexed
             if let Some(index_db) = indexes.get(&attr_lower) {
-                if !values.is_empty() {
-                    let presence_key = Self::presence_index_key(dn);
-                    txn.del(*index_db, &presence_key.as_bytes(), None)
-                        .or_else(|e| match e {
-                            lmdb::Error::NotFound => Ok(()),
-                            _ => Err(BackendError::Storage(format!(
-                                "Failed to remove presence index for {}: {}",
-                                attr_name, e
-                            ))),
-                        })?;
-                }
-
-                for value in values {
-                    let value_lower = value.to_lowercase();
-                    let index_key = Self::equality_index_key(&value_lower, dn);
-                    txn.del(*index_db, &index_key.as_bytes(), None)
-                        .or_else(|e| match e {
-                            lmdb::Error::NotFound => Ok(()), // Already removed, that's OK
-                            _ => Err(BackendError::Storage(format!(
-                                "Failed to remove index for {}:{}: {}",
-                                attr_name, value, e
-                            ))),
-                        })?;
+                if let Some(index_types) = self.index_config.index_types_for(&attr_lower) {
+                    for (_, index_key) in
+                        Self::attribute_index_keys(*index_db, dn, values, &index_types)
+                    {
+                        txn.del(*index_db, &index_key.as_bytes(), None)
+                            .or_else(|e| match e {
+                                lmdb::Error::NotFound => Ok(()), // Already removed, that's OK
+                                _ => Err(BackendError::Storage(format!(
+                                    "Failed to remove index for {}: {}",
+                                    attr_name, e
+                                ))),
+                            })?;
+                    }
                 }
             }
         }
@@ -1573,6 +1784,10 @@ impl LmdbBackend {
     ) -> Result<Vec<String>, BackendError> {
         let attr_lower = attribute.to_lowercase();
         let value_lower = value.to_lowercase();
+
+        if !self.has_index_type(&attr_lower, IndexType::Equality) {
+            return Ok(Vec::new());
+        }
 
         let indexes = self
             .attr_indexes
@@ -1602,6 +1817,11 @@ impl LmdbBackend {
 
     fn search_present_by_index(&self, attribute: &str) -> Result<Vec<String>, BackendError> {
         let attr_lower = attribute.to_lowercase();
+
+        if !self.has_index_type(&attr_lower, IndexType::Presence) {
+            return Ok(Vec::new());
+        }
+
         let indexes = self
             .attr_indexes
             .try_read()
@@ -1620,6 +1840,135 @@ impl LmdbBackend {
             .map_err(|e| BackendError::Storage(format!("Failed to open cursor: {}", e)))?;
         let search_prefix = Self::presence_index_prefix();
         Self::collect_index_dns_by_prefix(&mut cursor, search_prefix.as_bytes())
+    }
+
+    fn search_substring_by_index(
+        &self,
+        attribute: &str,
+        parts: &[SearchSubstringPart],
+    ) -> Result<Option<Vec<String>>, BackendError> {
+        let attr_lower = attribute.to_lowercase();
+
+        if !self.has_index_type(&attr_lower, IndexType::Substring) {
+            return Ok(None);
+        }
+
+        let Some(token) = Self::substring_query_token(parts) else {
+            return Ok(None);
+        };
+
+        let indexes = self
+            .attr_indexes
+            .try_read()
+            .map_err(|e| BackendError::Storage(format!("Failed to acquire index lock: {}", e)))?;
+        let index_db = match indexes.get(&attr_lower) {
+            Some(db) => *db,
+            None => return Ok(None),
+        };
+
+        let txn = self
+            .env
+            .begin_ro_txn()
+            .map_err(|e| BackendError::Storage(format!("Failed to begin read txn: {}", e)))?;
+        let mut cursor = txn
+            .open_ro_cursor(index_db)
+            .map_err(|e| BackendError::Storage(format!("Failed to open cursor: {}", e)))?;
+        let search_prefix = Self::substring_index_prefix(&token);
+        Self::collect_index_dns_by_prefix(&mut cursor, search_prefix.as_bytes()).map(Some)
+    }
+
+    fn search_ordering_by_index(
+        &self,
+        attribute: &str,
+        value: &str,
+        greater_or_equal: bool,
+    ) -> Result<Option<Vec<String>>, BackendError> {
+        let attr_lower = attribute.to_lowercase();
+
+        if !self.has_index_type(&attr_lower, IndexType::Ordering) {
+            return Ok(None);
+        }
+
+        let indexes = self
+            .attr_indexes
+            .try_read()
+            .map_err(|e| BackendError::Storage(format!("Failed to acquire index lock: {}", e)))?;
+        let index_db = match indexes.get(&attr_lower) {
+            Some(db) => *db,
+            None => return Ok(None),
+        };
+
+        let txn = self
+            .env
+            .begin_ro_txn()
+            .map_err(|e| BackendError::Storage(format!("Failed to begin read txn: {}", e)))?;
+        let mut cursor = txn
+            .open_ro_cursor(index_db)
+            .map_err(|e| BackendError::Storage(format!("Failed to open cursor: {}", e)))?;
+
+        let value_lower = value.to_lowercase();
+        let seek_key = if greater_or_equal {
+            Self::ordering_index_key(&value_lower, "")
+        } else {
+            Self::ordering_index_prefix().to_string()
+        };
+        let first_key = match cursor.get(Some(seek_key.as_bytes()), None, LMDB_SET_RANGE_OP) {
+            Ok((Some(key), _)) => key,
+            Ok((None, _)) | Err(lmdb::Error::NotFound) => return Ok(Some(Vec::new())),
+            Err(e) => {
+                return Err(BackendError::Storage(format!(
+                    "Failed to seek ordering index cursor: {}",
+                    e
+                )))
+            }
+        };
+
+        if !first_key.starts_with(Self::ordering_index_prefix().as_bytes()) {
+            return Ok(Some(Vec::new()));
+        }
+
+        let mut results = Vec::new();
+        if Self::push_ordering_candidate(first_key, &value_lower, greater_or_equal, &mut results)? {
+            for (key, _value) in cursor.iter() {
+                if !key.starts_with(Self::ordering_index_prefix().as_bytes()) {
+                    break;
+                }
+                if !Self::push_ordering_candidate(
+                    key,
+                    &value_lower,
+                    greater_or_equal,
+                    &mut results,
+                )? {
+                    break;
+                }
+            }
+        }
+
+        Ok(Some(results))
+    }
+
+    fn push_ordering_candidate(
+        key: &[u8],
+        target_value: &str,
+        greater_or_equal: bool,
+        results: &mut Vec<String>,
+    ) -> Result<bool, BackendError> {
+        let Some((value, dn)) = Self::ordering_index_key_parts(key)? else {
+            return Ok(false);
+        };
+
+        let in_range = if greater_or_equal {
+            value >= target_value
+        } else {
+            value <= target_value
+        };
+
+        if in_range {
+            results.push(dn.to_string());
+            Ok(true)
+        } else {
+            Ok(greater_or_equal)
+        }
     }
 
     fn load_entries_by_dns(
@@ -1653,11 +2002,18 @@ impl LmdbBackend {
 
     /// Check if an attribute is indexed
     pub fn is_indexed(&self, attribute: &str) -> bool {
-        let attr_lower = attribute.to_lowercase();
         self.index_config
-            .indexed_attributes
-            .iter()
-            .any(|a| a.to_lowercase() == attr_lower)
+            .effective_index_types()
+            .contains_key(&attribute.to_lowercase())
+    }
+
+    /// Check if an attribute has a specific index type configured.
+    pub fn has_attribute_index(&self, attribute: &str, index_type: IndexType) -> bool {
+        self.has_index_type(attribute, index_type)
+    }
+
+    fn has_index_type(&self, attribute: &str, index_type: IndexType) -> bool {
+        self.index_config.has_index_type(attribute, index_type)
     }
 
     pub fn configured_max_readers(&self) -> u32 {
@@ -1929,16 +2285,36 @@ impl DirectoryBackend for LmdbBackend {
 
         let candidates = match hint {
             SearchCandidateHint::Equality { attribute, value } => {
-                if !self.is_indexed(&attribute) {
+                if !self.has_index_type(&attribute, IndexType::Equality) {
                     return self.search_entries(base_dn, scope).await;
                 }
                 self.search_by_index(&attribute, &value)?
             }
             SearchCandidateHint::Present { attribute } => {
-                if !self.is_indexed(&attribute) {
+                if !self.has_index_type(&attribute, IndexType::Presence) {
                     return self.search_entries(base_dn, scope).await;
                 }
                 self.search_present_by_index(&attribute)?
+            }
+            SearchCandidateHint::Substring { attribute, parts } => {
+                let Some(candidates) = self.search_substring_by_index(&attribute, &parts)? else {
+                    return self.search_entries(base_dn, scope).await;
+                };
+                candidates
+            }
+            SearchCandidateHint::GreaterOrEqual { attribute, value } => {
+                let Some(candidates) = self.search_ordering_by_index(&attribute, &value, true)?
+                else {
+                    return self.search_entries(base_dn, scope).await;
+                };
+                candidates
+            }
+            SearchCandidateHint::LessOrEqual { attribute, value } => {
+                let Some(candidates) = self.search_ordering_by_index(&attribute, &value, false)?
+                else {
+                    return self.search_entries(base_dn, scope).await;
+                };
+                candidates
             }
         };
 
@@ -2569,6 +2945,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let config = IndexConfig {
             indexed_attributes: vec!["custom".to_string(), "special".to_string()],
+            attribute_indexes: Vec::new(),
         };
         let backend = LmdbBackend::new_with_config(dir.path(), 100, 1, config).unwrap();
 
@@ -2587,10 +2964,173 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_custom_index_backfilled_for_existing_entries_on_reopen() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().to_path_buf();
+
+        {
+            let backend = LmdbBackend::new_with_config(
+                &db_path,
+                100,
+                1,
+                IndexConfig {
+                    indexed_attributes: Vec::new(),
+                    attribute_indexes: Vec::new(),
+                },
+            )
+            .unwrap();
+
+            let mut attributes = HashMap::new();
+            attributes.insert("employeeNumber".to_string(), vec!["12345".to_string()]);
+            attributes.insert("cn".to_string(), vec!["Alice".to_string()]);
+            let entry = DirectoryEntry::new("uid=alice,dc=example,dc=org", attributes);
+            backend.add_entry(entry, vec![]).await.unwrap();
+
+            let results = backend.search_by_index("employeeNumber", "12345").unwrap();
+            assert!(results.is_empty());
+        }
+
+        let backend = LmdbBackend::new_with_config(
+            &db_path,
+            100,
+            1,
+            IndexConfig {
+                indexed_attributes: vec!["employeeNumber".to_string()],
+                attribute_indexes: Vec::new(),
+            },
+        )
+        .unwrap();
+
+        let results = backend.search_by_index("employeeNumber", "12345").unwrap();
+        assert_eq!(results, vec!["uid=alice,dc=example,dc=org".to_string()]);
+
+        let present_results = backend.search_present_by_index("employeeNumber").unwrap();
+        assert_eq!(
+            present_results,
+            vec!["uid=alice,dc=example,dc=org".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_custom_index_backfill_handles_attribute_without_existing_values() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().to_path_buf();
+
+        {
+            let backend = LmdbBackend::new_with_config(
+                &db_path,
+                100,
+                1,
+                IndexConfig {
+                    indexed_attributes: Vec::new(),
+                    attribute_indexes: Vec::new(),
+                },
+            )
+            .unwrap();
+
+            let mut attributes = HashMap::new();
+            attributes.insert("cn".to_string(), vec!["Alice".to_string()]);
+            let entry = DirectoryEntry::new("uid=alice,dc=example,dc=org", attributes);
+            backend.add_entry(entry, vec![]).await.unwrap();
+        }
+
+        let backend = LmdbBackend::new_with_config(
+            &db_path,
+            100,
+            1,
+            IndexConfig {
+                indexed_attributes: vec!["employeeNumber".to_string()],
+                attribute_indexes: Vec::new(),
+            },
+        )
+        .unwrap();
+
+        assert!(backend.is_indexed("employeeNumber"));
+        assert!(backend
+            .search_by_index("employeeNumber", "12345")
+            .unwrap()
+            .is_empty());
+        assert!(backend
+            .search_present_by_index("employeeNumber")
+            .unwrap()
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_reenabled_index_rebuilds_after_disabled_changes() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().to_path_buf();
+
+        {
+            let backend = LmdbBackend::new_with_config(
+                &db_path,
+                100,
+                1,
+                IndexConfig {
+                    indexed_attributes: vec!["custom".to_string()],
+                    attribute_indexes: Vec::new(),
+                },
+            )
+            .unwrap();
+
+            let mut attributes = HashMap::new();
+            attributes.insert("custom".to_string(), vec!["old".to_string()]);
+            let entry = DirectoryEntry::new("uid=test,dc=example,dc=org", attributes);
+            backend.add_entry(entry, vec![]).await.unwrap();
+            assert_eq!(backend.search_by_index("custom", "old").unwrap().len(), 1);
+        }
+
+        {
+            let backend = LmdbBackend::new_with_config(
+                &db_path,
+                100,
+                1,
+                IndexConfig {
+                    indexed_attributes: Vec::new(),
+                    attribute_indexes: Vec::new(),
+                },
+            )
+            .unwrap();
+
+            backend
+                .modify_entry(
+                    "uid=test,dc=example,dc=org",
+                    vec![Modification {
+                        operation: ModifyOperation::Replace,
+                        attribute: "custom".to_string(),
+                        values: vec!["new".to_string()],
+                    }],
+                )
+                .await
+                .unwrap();
+
+            assert!(backend.search_by_index("custom", "new").unwrap().is_empty());
+        }
+
+        let backend = LmdbBackend::new_with_config(
+            &db_path,
+            100,
+            1,
+            IndexConfig {
+                indexed_attributes: vec!["custom".to_string()],
+                attribute_indexes: Vec::new(),
+            },
+        )
+        .unwrap();
+
+        assert!(backend.search_by_index("custom", "old").unwrap().is_empty());
+        assert_eq!(
+            backend.search_by_index("custom", "new").unwrap(),
+            vec!["uid=test,dc=example,dc=org".to_string()]
+        );
+    }
+
+    #[tokio::test]
     async fn test_runtime_config_applies_indexes_and_max_readers() {
         let dir = tempdir().unwrap();
         let config = IndexConfig {
             indexed_attributes: vec!["departmentnumber".to_string()],
+            attribute_indexes: Vec::new(),
         };
         let backend = LmdbBackend::new_with_runtime_config(dir.path(), 100, 1, config, 64).unwrap();
 
@@ -2609,6 +3149,264 @@ mod tests {
 
         let results = backend.search_by_index("departmentNumber", "42").unwrap();
         assert_eq!(results, vec!["uid=test,dc=example,dc=org".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn test_typed_substring_index_hint_uses_index_candidates() {
+        let dir = tempdir().unwrap();
+        let backend = LmdbBackend::new_with_config(
+            dir.path(),
+            100,
+            1,
+            IndexConfig {
+                indexed_attributes: Vec::new(),
+                attribute_indexes: vec![AttributeIndexConfig {
+                    attribute: "description".to_string(),
+                    index_types: vec![IndexType::Substring],
+                }],
+            },
+        )
+        .unwrap();
+
+        let mut alice_attributes = HashMap::new();
+        alice_attributes.insert("description".to_string(), vec!["alpha marker".to_string()]);
+        let alice = DirectoryEntry::new("uid=alice,dc=example,dc=org", alice_attributes);
+        backend.add_entry(alice, vec![]).await.unwrap();
+
+        let mut bob_attributes = HashMap::new();
+        bob_attributes.insert("description".to_string(), vec!["omega".to_string()]);
+        let bob = DirectoryEntry::new("uid=bob,dc=example,dc=org", bob_attributes);
+        backend.add_entry(bob, vec![]).await.unwrap();
+
+        let mut multi_value_attributes = HashMap::new();
+        multi_value_attributes.insert(
+            "description".to_string(),
+            vec!["plain".to_string(), "zebra finish".to_string()],
+        );
+        let multi_value =
+            DirectoryEntry::new("uid=multi,dc=example,dc=org", multi_value_attributes);
+        backend.add_entry(multi_value, vec![]).await.unwrap();
+
+        assert!(backend
+            .search_by_index("description", "alpha marker")
+            .unwrap()
+            .is_empty());
+
+        let results = backend
+            .search_entries_with_hint(
+                "dc=example,dc=org",
+                SearchScope(2),
+                Some(SearchCandidateHint::Substring {
+                    attribute: "description".to_string(),
+                    parts: vec![SearchSubstringPart::Any("pha".to_string())],
+                }),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].dn, "uid=alice,dc=example,dc=org");
+
+        let initial_results = backend
+            .search_entries_with_hint(
+                "dc=example,dc=org",
+                SearchScope(2),
+                Some(SearchCandidateHint::Substring {
+                    attribute: "description".to_string(),
+                    parts: vec![SearchSubstringPart::Initial("ALP".to_string())],
+                }),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(initial_results.len(), 1);
+        assert_eq!(initial_results[0].dn, "uid=alice,dc=example,dc=org");
+
+        let final_results = backend
+            .search_entries_with_hint(
+                "dc=example,dc=org",
+                SearchScope(2),
+                Some(SearchCandidateHint::Substring {
+                    attribute: "description".to_string(),
+                    parts: vec![SearchSubstringPart::Final("KER".to_string())],
+                }),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(final_results.len(), 1);
+        assert_eq!(final_results[0].dn, "uid=alice,dc=example,dc=org");
+
+        let multi_value_results = backend
+            .search_entries_with_hint(
+                "dc=example,dc=org",
+                SearchScope(2),
+                Some(SearchCandidateHint::Substring {
+                    attribute: "description".to_string(),
+                    parts: vec![SearchSubstringPart::Any("BRA".to_string())],
+                }),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(multi_value_results.len(), 1);
+        assert_eq!(multi_value_results[0].dn, "uid=multi,dc=example,dc=org");
+    }
+
+    #[tokio::test]
+    async fn test_typed_ordering_index_backfilled_for_existing_entries() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().to_path_buf();
+
+        {
+            let backend = LmdbBackend::new_with_config(
+                &db_path,
+                100,
+                1,
+                IndexConfig {
+                    indexed_attributes: Vec::new(),
+                    attribute_indexes: Vec::new(),
+                },
+            )
+            .unwrap();
+
+            for (uid, serial) in [("low", "010"), ("mid", "020"), ("high", "030")] {
+                let mut attributes = HashMap::new();
+                attributes.insert("serialNumber".to_string(), vec![serial.to_string()]);
+                let entry = DirectoryEntry::new(format!("uid={uid},dc=example,dc=org"), attributes);
+                backend.add_entry(entry, vec![]).await.unwrap();
+            }
+        }
+
+        let backend = LmdbBackend::new_with_config(
+            &db_path,
+            100,
+            1,
+            IndexConfig {
+                indexed_attributes: Vec::new(),
+                attribute_indexes: vec![AttributeIndexConfig {
+                    attribute: "serialNumber".to_string(),
+                    index_types: vec![IndexType::Ordering],
+                }],
+            },
+        )
+        .unwrap();
+
+        let greater_or_equal = backend
+            .search_entries_with_hint(
+                "dc=example,dc=org",
+                SearchScope(2),
+                Some(SearchCandidateHint::GreaterOrEqual {
+                    attribute: "serialNumber".to_string(),
+                    value: "020".to_string(),
+                }),
+            )
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|entry| entry.dn)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            greater_or_equal,
+            vec![
+                "uid=mid,dc=example,dc=org".to_string(),
+                "uid=high,dc=example,dc=org".to_string()
+            ]
+        );
+
+        let less_or_equal = backend
+            .search_entries_with_hint(
+                "dc=example,dc=org",
+                SearchScope(2),
+                Some(SearchCandidateHint::LessOrEqual {
+                    attribute: "serialNumber".to_string(),
+                    value: "020".to_string(),
+                }),
+            )
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|entry| entry.dn)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            less_or_equal,
+            vec![
+                "uid=low,dc=example,dc=org".to_string(),
+                "uid=mid,dc=example,dc=org".to_string()
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_typed_ordering_index_handles_multivalue_scope_and_case() {
+        let dir = tempdir().unwrap();
+        let backend = LmdbBackend::new_with_config(
+            dir.path(),
+            100,
+            1,
+            IndexConfig {
+                indexed_attributes: Vec::new(),
+                attribute_indexes: vec![AttributeIndexConfig {
+                    attribute: "code".to_string(),
+                    index_types: vec![IndexType::Ordering],
+                }],
+            },
+        )
+        .unwrap();
+
+        let mut alpha_attributes = HashMap::new();
+        alpha_attributes.insert("code".to_string(), vec!["Alpha".to_string()]);
+        let alpha = DirectoryEntry::new("uid=alpha,ou=people,dc=example,dc=org", alpha_attributes);
+        backend.add_entry(alpha, vec![]).await.unwrap();
+
+        let mut multi_value_attributes = HashMap::new();
+        multi_value_attributes.insert(
+            "code".to_string(),
+            vec!["Lima".to_string(), "Zulu".to_string()],
+        );
+        let multi_value = DirectoryEntry::new(
+            "uid=multi,ou=people,dc=example,dc=org",
+            multi_value_attributes,
+        );
+        backend.add_entry(multi_value, vec![]).await.unwrap();
+
+        let mut out_of_scope_attributes = HashMap::new();
+        out_of_scope_attributes.insert("code".to_string(), vec!["Zulu".to_string()]);
+        let out_of_scope = DirectoryEntry::new(
+            "uid=outside,ou=ops,dc=example,dc=org",
+            out_of_scope_attributes,
+        );
+        backend.add_entry(out_of_scope, vec![]).await.unwrap();
+
+        let scoped_ge = backend
+            .search_entries_with_hint(
+                "ou=people,dc=example,dc=org",
+                SearchScope(2),
+                Some(SearchCandidateHint::GreaterOrEqual {
+                    attribute: "code".to_string(),
+                    value: "YANKEE".to_string(),
+                }),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(scoped_ge.len(), 1);
+        assert_eq!(scoped_ge[0].dn, "uid=multi,ou=people,dc=example,dc=org");
+
+        let less_or_equal = backend
+            .search_entries_with_hint(
+                "dc=example,dc=org",
+                SearchScope(2),
+                Some(SearchCandidateHint::LessOrEqual {
+                    attribute: "code".to_string(),
+                    value: "BRAVO".to_string(),
+                }),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(less_or_equal.len(), 1);
+        assert_eq!(less_or_equal[0].dn, "uid=alpha,ou=people,dc=example,dc=org");
     }
 
     #[tokio::test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -195,6 +195,21 @@ pub struct BackendSettings {
     /// Indexed attributes
     #[serde(default = "default_indexed_attributes")]
     pub indexed_attributes: Vec<String>,
+
+    /// Typed attribute indexes.
+    #[serde(default)]
+    pub indexes: Vec<AttributeIndexSettings>,
+}
+
+/// Typed backend index settings for one attribute.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AttributeIndexSettings {
+    /// Attribute to index.
+    pub attribute: String,
+
+    /// Index types to maintain, e.g. "equality", "presence", "substring", "ordering".
+    #[serde(default)]
+    pub types: Vec<String>,
 }
 
 /// TLS settings
@@ -779,6 +794,13 @@ fn default_cache_size() -> usize {
     1000
 }
 
+fn is_valid_backend_index_type(index_type: &str) -> bool {
+    matches!(
+        index_type.to_ascii_lowercase().as_str(),
+        "equality" | "eq" | "presence" | "pres" | "substring" | "sub" | "ordering" | "ord"
+    )
+}
+
 // Default implementations
 impl Default for ServerSettings {
     fn default() -> Self {
@@ -812,6 +834,7 @@ impl Default for BackendSettings {
             lmdb_max_readers: default_lmdb_max_readers(),
             import_sample_data: false,
             indexed_attributes: default_indexed_attributes(),
+            indexes: Vec::new(),
         }
     }
 }
@@ -1293,6 +1316,34 @@ impl ServerConfig {
                 "Invalid backend type: {}",
                 self.backend.backend_type
             )));
+        }
+        for attribute in &self.backend.indexed_attributes {
+            if attribute.trim().is_empty() {
+                return Err(ConfigError::ValidationError(
+                    "backend.indexed_attributes cannot contain empty attribute names".to_string(),
+                ));
+            }
+        }
+        for index in &self.backend.indexes {
+            if index.attribute.trim().is_empty() {
+                return Err(ConfigError::ValidationError(
+                    "backend.indexes attribute cannot be empty".to_string(),
+                ));
+            }
+            if index.types.is_empty() {
+                return Err(ConfigError::ValidationError(format!(
+                    "backend.indexes for {} must configure at least one index type",
+                    index.attribute
+                )));
+            }
+            for index_type in &index.types {
+                if !is_valid_backend_index_type(index_type) {
+                    return Err(ConfigError::ValidationError(format!(
+                        "unsupported backend index type for {}: {}",
+                        index.attribute, index_type
+                    )));
+                }
+            }
         }
 
         // Validate TLS settings

--- a/src/ldap_filter_eval.rs
+++ b/src/ldap_filter_eval.rs
@@ -1,4 +1,4 @@
-use crate::backend::{DirectoryEntry, SearchCandidateHint};
+use crate::backend::{DirectoryEntry, SearchCandidateHint, SearchSubstringPart};
 use crate::replication::RenameChange;
 use crate::replication_provider_fsm::{ChangeType, ChangelogEntry};
 use crate::search_fsm::SearchEntry;
@@ -22,6 +22,7 @@ const EXTENSIBLE_MATCH: u64 = 9;
 const SUBSTRING_INITIAL: u64 = 0;
 const SUBSTRING_ANY: u64 = 1;
 const SUBSTRING_FINAL: u64 = 2;
+const SUBSTRING_INDEX_MIN_CHARS: usize = 3;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum CompiledLdapFilter {
@@ -198,6 +199,30 @@ impl CompiledLdapFilter {
             }),
             Self::Present { attribute } => Some(SearchCandidateHint::Present {
                 attribute: attribute.clone(),
+            }),
+            Self::Substrings { attribute, parts }
+                if parts.iter().any(|part| {
+                    substring_part_value(part).chars().count() >= SUBSTRING_INDEX_MIN_CHARS
+                }) =>
+            {
+                Some(SearchCandidateHint::Substring {
+                    attribute: attribute.clone(),
+                    parts: parts.iter().map(SearchSubstringPart::from).collect(),
+                })
+            }
+            Self::GreaterOrEqual { attribute, value } => {
+                Some(SearchCandidateHint::GreaterOrEqual {
+                    attribute: attribute.clone(),
+                    value: value.clone(),
+                })
+            }
+            Self::LessOrEqual { attribute, value } => Some(SearchCandidateHint::LessOrEqual {
+                attribute: attribute.clone(),
+                value: value.clone(),
+            }),
+            Self::ApproxMatch { attribute, value } => Some(SearchCandidateHint::Equality {
+                attribute: attribute.clone(),
+                value: value.clone(),
             }),
             _ => None,
         }
@@ -387,6 +412,16 @@ impl CompiledLdapFilter {
     }
 }
 
+impl From<&SubstringPart> for SearchSubstringPart {
+    fn from(part: &SubstringPart) -> Self {
+        match part {
+            SubstringPart::Initial(value) => Self::Initial(value.clone()),
+            SubstringPart::Any(value) => Self::Any(value.clone()),
+            SubstringPart::Final(value) => Self::Final(value.clone()),
+        }
+    }
+}
+
 fn change_type_label(change_type: &ChangeType) -> &'static str {
     match change_type {
         ChangeType::Add => "add",
@@ -504,6 +539,14 @@ fn convert_search_substring(substring: &Substring<'_>) -> SubstringPart {
         Substring::Initial(segment) => SubstringPart::Initial(bytes_to_string(segment.0.as_ref())),
         Substring::Any(segment) => SubstringPart::Any(bytes_to_string(segment.0.as_ref())),
         Substring::Final(segment) => SubstringPart::Final(bytes_to_string(segment.0.as_ref())),
+    }
+}
+
+fn substring_part_value(part: &SubstringPart) -> &str {
+    match part {
+        SubstringPart::Initial(value) | SubstringPart::Any(value) | SubstringPart::Final(value) => {
+            value
+        }
     }
 }
 
@@ -716,6 +759,39 @@ mod tests {
         assert!(ignore_case.matches(&entry));
         assert!(dn_attribute.matches(&entry));
         assert!(!unsupported_rule.matches(&entry));
+    }
+
+    #[test]
+    fn compile_filter_extracts_substring_and_ordering_hints() {
+        assert_eq!(
+            extract_search_candidate_hint_from_str("(cn=Ali*)"),
+            Some(SearchCandidateHint::Substring {
+                attribute: "cn".to_string(),
+                parts: vec![SearchSubstringPart::Initial("Ali".to_string())],
+            })
+        );
+        assert_eq!(
+            extract_search_candidate_hint_from_str("(entryCSN>=020)"),
+            Some(SearchCandidateHint::GreaterOrEqual {
+                attribute: "entrycsn".to_string(),
+                value: "020".to_string(),
+            })
+        );
+        assert_eq!(
+            extract_search_candidate_hint_from_str("(entryCSN<=020)"),
+            Some(SearchCandidateHint::LessOrEqual {
+                attribute: "entrycsn".to_string(),
+                value: "020".to_string(),
+            })
+        );
+        assert_eq!(
+            extract_search_candidate_hint_from_str("(cn~=Alice)"),
+            Some(SearchCandidateHint::Equality {
+                attribute: "cn".to_string(),
+                value: "Alice".to_string(),
+            })
+        );
+        assert_eq!(extract_search_candidate_hint_from_str("(cn=Al*)"), None);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use clap::Parser;
 use opendr::aci::AciEngine;
 use opendr::audit::{AuditConfig, AuditFormat, AuditLevel, AuditLogger};
 use opendr::backend::{DirectoryBackend, DirectoryEntry, MockBackend};
-use opendr::backend_lmdb::{IndexConfig, LmdbBackend};
+use opendr::backend_lmdb::{AttributeIndexConfig, IndexConfig, IndexType, LmdbBackend};
 use opendr::config::ServerConfig;
 use opendr::fsm_server;
 use opendr::metrics::MetricsCollector;
@@ -147,12 +147,33 @@ async fn run(args: Args) -> Result<(), Box<dyn Error>> {
                 // Create LMDB backend with configured max size (convert to MB)
                 let max_size_mb = config.backend.lmdb_max_size / (1024 * 1024);
                 let replica_id = config.server.replica_id;
+                let mut attribute_indexes = Vec::new();
+                if config.performance.indexing_enabled {
+                    for index in &config.backend.indexes {
+                        let mut index_types = Vec::new();
+                        for index_type in &index.types {
+                            let Some(index_type) = IndexType::from_name(index_type) else {
+                                return Err(format!(
+                                    "unsupported index type for {}: {}",
+                                    index.attribute, index_type
+                                )
+                                .into());
+                            };
+                            index_types.push(index_type);
+                        }
+                        attribute_indexes.push(AttributeIndexConfig {
+                            attribute: index.attribute.clone(),
+                            index_types,
+                        });
+                    }
+                }
                 let index_config = IndexConfig {
                     indexed_attributes: if config.performance.indexing_enabled {
                         config.backend.indexed_attributes.clone()
                     } else {
                         Vec::new()
                     },
+                    attribute_indexes,
                 };
                 println!(
                     "LMDB entry cache capacity: {}",

--- a/tests/config_integration.rs
+++ b/tests/config_integration.rs
@@ -676,6 +676,62 @@ indexed_attributes = ["cn", "uid", "mail", "sn", "givenName", "objectClass", "ou
 }
 
 #[test]
+fn test_typed_backend_indexes_config() {
+    let toml = r#"
+[backend]
+indexed_attributes = []
+
+[[backend.indexes]]
+attribute = "cn"
+types = ["equality", "presence", "substring"]
+
+[[backend.indexes]]
+attribute = "entryCSN"
+types = ["ordering"]
+    "#;
+
+    let config = ServerConfig::from_toml_str(toml).unwrap();
+    config.validate().unwrap();
+
+    assert_eq!(config.backend.indexes.len(), 2);
+    assert_eq!(config.backend.indexes[0].attribute, "cn");
+    assert_eq!(
+        config.backend.indexes[0].types,
+        vec![
+            "equality".to_string(),
+            "presence".to_string(),
+            "substring".to_string()
+        ]
+    );
+    assert_eq!(config.backend.indexes[1].attribute, "entryCSN");
+    assert_eq!(
+        config.backend.indexes[1].types,
+        vec!["ordering".to_string()]
+    );
+}
+
+#[test]
+fn test_invalid_backend_index_type_validation() {
+    let toml = r#"
+[backend]
+indexed_attributes = []
+
+[[backend.indexes]]
+attribute = "cn"
+types = ["bogus"]
+    "#;
+
+    let config = ServerConfig::from_toml_str(toml).unwrap();
+    let result = config.validate();
+
+    assert!(result.is_err());
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("unsupported backend index type for cn: bogus"));
+}
+
+#[test]
 fn test_max_connections_validation() {
     let toml = r#"
 [resources]

--- a/tests/indexing_integration.rs
+++ b/tests/indexing_integration.rs
@@ -13,8 +13,9 @@ use std::time::Instant;
 use ldap_parser::ldap::SearchScope;
 use opendr::backend::{
     DirectoryBackend, DirectoryEntry, Modification, ModifyOperation, SearchCandidateHint,
+    SearchSubstringPart,
 };
-use opendr::backend_lmdb::{IndexConfig, LmdbBackend};
+use opendr::backend_lmdb::{AttributeIndexConfig, IndexConfig, IndexType, LmdbBackend};
 use tempfile::TempDir;
 
 /// Helper to create a test backend with default configuration
@@ -26,8 +27,25 @@ fn create_test_backend(temp_dir: &TempDir) -> LmdbBackend {
 fn create_custom_backend(temp_dir: &TempDir, indexed_attrs: Vec<String>) -> LmdbBackend {
     let config = IndexConfig {
         indexed_attributes: indexed_attrs,
+        attribute_indexes: Vec::new(),
     };
     LmdbBackend::new_with_config(temp_dir.path(), 100, 1, config).unwrap()
+}
+
+fn create_typed_backend(
+    temp_dir: &TempDir,
+    attribute_indexes: Vec<AttributeIndexConfig>,
+) -> LmdbBackend {
+    LmdbBackend::new_with_config(
+        temp_dir.path(),
+        100,
+        1,
+        IndexConfig {
+            indexed_attributes: Vec::new(),
+            attribute_indexes,
+        },
+    )
+    .unwrap()
 }
 
 #[tokio::test]
@@ -348,6 +366,199 @@ async fn test_custom_index_configuration() {
 
     let results = backend.search_by_index("title", "Senior Engineer").unwrap();
     assert_eq!(results.len(), 1);
+}
+
+#[tokio::test]
+async fn test_typed_substring_index_configuration_and_candidates() {
+    let temp_dir = TempDir::new().unwrap();
+    let backend = create_typed_backend(
+        &temp_dir,
+        vec![AttributeIndexConfig {
+            attribute: "description".to_string(),
+            index_types: vec![IndexType::Substring],
+        }],
+    );
+
+    assert!(backend.is_indexed("description"));
+    assert!(backend.has_attribute_index("description", IndexType::Substring));
+    assert!(!backend.has_attribute_index("description", IndexType::Equality));
+    assert!(!backend.has_attribute_index("description", IndexType::Presence));
+    assert!(!backend.has_attribute_index("description", IndexType::Ordering));
+
+    let mut alice_attributes = HashMap::new();
+    alice_attributes.insert("description".to_string(), vec!["alpha marker".to_string()]);
+    let alice = DirectoryEntry::new("uid=alice,ou=people,dc=example,dc=org", alice_attributes);
+    backend.add_entry(alice, vec![]).await.unwrap();
+
+    let mut bob_attributes = HashMap::new();
+    bob_attributes.insert("description".to_string(), vec!["omega marker".to_string()]);
+    let bob = DirectoryEntry::new("uid=bob,ou=people,dc=example,dc=org", bob_attributes);
+    backend.add_entry(bob, vec![]).await.unwrap();
+
+    assert!(backend
+        .search_by_index("description", "alpha marker")
+        .unwrap()
+        .is_empty());
+
+    let results = backend
+        .search_entries_with_hint(
+            "ou=people,dc=example,dc=org",
+            SearchScope(2),
+            Some(SearchCandidateHint::Substring {
+                attribute: "description".to_string(),
+                parts: vec![SearchSubstringPart::Any("pha".to_string())],
+            }),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].dn, "uid=alice,ou=people,dc=example,dc=org");
+}
+
+#[tokio::test]
+async fn test_typed_ordering_index_configuration_and_candidates() {
+    let temp_dir = TempDir::new().unwrap();
+    let backend = create_typed_backend(
+        &temp_dir,
+        vec![AttributeIndexConfig {
+            attribute: "serialNumber".to_string(),
+            index_types: vec![IndexType::Ordering],
+        }],
+    );
+
+    assert!(backend.is_indexed("serialNumber"));
+    assert!(backend.has_attribute_index("serialNumber", IndexType::Ordering));
+    assert!(!backend.has_attribute_index("serialNumber", IndexType::Equality));
+    assert!(!backend.has_attribute_index("serialNumber", IndexType::Presence));
+    assert!(!backend.has_attribute_index("serialNumber", IndexType::Substring));
+
+    for (uid, serial) in [("low", "010"), ("mid", "020"), ("high", "030")] {
+        let mut attributes = HashMap::new();
+        attributes.insert("serialNumber".to_string(), vec![serial.to_string()]);
+        backend
+            .add_entry(
+                DirectoryEntry::new(format!("uid={uid},ou=people,dc=example,dc=org"), attributes),
+                vec![],
+            )
+            .await
+            .unwrap();
+    }
+
+    assert!(backend
+        .search_by_index("serialNumber", "020")
+        .unwrap()
+        .is_empty());
+
+    let greater_or_equal = backend
+        .search_entries_with_hint(
+            "ou=people,dc=example,dc=org",
+            SearchScope(2),
+            Some(SearchCandidateHint::GreaterOrEqual {
+                attribute: "serialNumber".to_string(),
+                value: "020".to_string(),
+            }),
+        )
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|entry| entry.dn)
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        greater_or_equal,
+        vec![
+            "uid=mid,ou=people,dc=example,dc=org".to_string(),
+            "uid=high,ou=people,dc=example,dc=org".to_string(),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn test_typed_indexes_are_backfilled_for_existing_data() {
+    let temp_dir = TempDir::new().unwrap();
+
+    {
+        let backend = create_typed_backend(&temp_dir, Vec::new());
+
+        for (uid, description, serial) in [
+            ("alice", "alpha marker", "010"),
+            ("bob", "omega marker", "020"),
+            ("carol", "gamma marker", "030"),
+        ] {
+            let mut attributes = HashMap::new();
+            attributes.insert("description".to_string(), vec![description.to_string()]);
+            attributes.insert("serialNumber".to_string(), vec![serial.to_string()]);
+            backend
+                .add_entry(
+                    DirectoryEntry::new(
+                        format!("uid={uid},ou=people,dc=example,dc=org"),
+                        attributes,
+                    ),
+                    vec![],
+                )
+                .await
+                .unwrap();
+        }
+    }
+
+    let backend = create_typed_backend(
+        &temp_dir,
+        vec![
+            AttributeIndexConfig {
+                attribute: "description".to_string(),
+                index_types: vec![IndexType::Substring],
+            },
+            AttributeIndexConfig {
+                attribute: "serialNumber".to_string(),
+                index_types: vec![IndexType::Ordering],
+            },
+        ],
+    );
+
+    assert!(backend.has_attribute_index("description", IndexType::Substring));
+    assert!(backend.has_attribute_index("serialNumber", IndexType::Ordering));
+
+    let substring_results = backend
+        .search_entries_with_hint(
+            "ou=people,dc=example,dc=org",
+            SearchScope(2),
+            Some(SearchCandidateHint::Substring {
+                attribute: "description".to_string(),
+                parts: vec![SearchSubstringPart::Any("pha".to_string())],
+            }),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(substring_results.len(), 1);
+    assert_eq!(
+        substring_results[0].dn,
+        "uid=alice,ou=people,dc=example,dc=org"
+    );
+
+    let ordering_results = backend
+        .search_entries_with_hint(
+            "ou=people,dc=example,dc=org",
+            SearchScope(2),
+            Some(SearchCandidateHint::LessOrEqual {
+                attribute: "serialNumber".to_string(),
+                value: "020".to_string(),
+            }),
+        )
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|entry| entry.dn)
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        ordering_results,
+        vec![
+            "uid=alice,ou=people,dc=example,dc=org".to_string(),
+            "uid=bob,ou=people,dc=example,dc=org".to_string(),
+        ]
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## **User description**
## Summary

Adds typed LMDB attribute index support without replacing LMDB.

- Adds typed index configuration for equality, presence, substring, and ordering indexes.
- Preserves legacy `indexed_attributes` behavior as equality + presence indexes.
- Adds LMDB substring and ordering key layouts, query hint dispatch, and index maintenance on add/modify/delete/rename.
- Adds startup backfill/reindex for new or changed index configuration over existing data.
- Maps approximate filters to equality hints under the server's current case-insensitive equality semantics.
- Adds integration tests that assert the exact index type is configured and prove substring/ordering hint searches use index candidates instead of falling back to a full-scope scan.
- Documents typed index configuration and backfill behavior.

Closes #81.
Closes #82.
Closes #83.
Closes #84.
Closes #85.

## Validation

- `cargo test`
- `cargo test --test indexing_integration`
- `cargo test backend_lmdb::tests --lib`
- `cargo fmt -- --check`
- `git diff --check`

Note: Rust reported the existing future-incompatibility warning for `konst v0.3.9`.


___

## **CodeAnt-AI Description**
**Add typed LMDB indexes for substring and ordering searches**

### What Changed
- LMDB index settings can now declare per-attribute index types, while the older shortcut still keeps equality and presence indexes
- Searches can now use substring candidates, and greater-than-or-equal / less-than-or-equal candidates when the matching index type is configured
- Existing data is rebuilt on startup when index settings change, so newly enabled indexes start working without re-adding entries
- Invalid or empty index settings are rejected at startup with clear validation errors
- The config file and README now show how to configure legacy and typed LMDB indexes

### Impact
`✅ Fewer full scans for substring searches`
`✅ Faster range lookups on indexed attributes`
`✅ Existing entries indexed after config changes`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
